### PR TITLE
fix(deps): update rust game (non-major)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.30.10"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+checksum = "898f5a568a84989b6c0f8caa50a93074b97dbdc58fc6d9543157bb4562758933"
 
 [[package]]
 name = "h2"
@@ -2761,7 +2761,7 @@ dependencies = [
  "bevy_ecs",
  "bitflags 2.13.0",
  "circular-buffer",
- "glam 0.30.10",
+ "glam 0.33.1",
  "libc",
  "num-width",
  "parking_lot",
@@ -2777,7 +2777,7 @@ dependencies = [
  "speculoos",
  "spin_sleep",
  "strum",
- "strum_macros",
+ "strum_macros 0.28.0",
  "thiserror 2.0.18",
  "thousands",
  "time",
@@ -3823,7 +3823,7 @@ dependencies = [
  "rustls",
  "serde",
  "sha2",
- "strum_macros",
+ "strum_macros 0.27.2",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -4458,15 +4458,27 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/pacman/Cargo.toml
+++ b/pacman/Cargo.toml
@@ -19,7 +19,7 @@ default-run = "pacman"
 
 [dependencies]
 bevy_ecs = "0.16.1"
-glam = "0.30.5"
+glam = "0.33.0"
 pathfinding = "4.14"
 tracing = { version = "0.1.41", features = ["max_level_trace", "release_max_level_debug"]}
 tracing-error = "0.2.0"
@@ -30,8 +30,8 @@ smallvec = "1.15.1"
 bitflags = "2.9.4"
 circular-buffer = "1.1.0"
 parking_lot = "0.12.3"
-strum = "0.27.2"
-strum_macros = "0.27.2"
+strum = "0.28.0"
+strum_macros = "0.28.0"
 thousands = "0.2.0"
 num-width = "0.1.0"
 # While not actively used in code, `build.rs` generates code that relies on this. Keep the versions synchronized.


### PR DESCRIPTION
Bumps game-crate deps grouped as non-major:
- `glam` 0.30 -> 0.33
- `strum` / `strum_macros` 0.27 -> 0.28

`Cargo.lock` regenerated for these crates. Supersedes #31, which Renovate autoclosed when `branchNameStrict` changed the computed branch name.

Compiles clean (`cargo check -p pacman`); the original #31 already had `checks`, `test`, and all desktop builds green — only the stale lock and the spurious docker-tag deploy failure (now fixed via branchNameStrict) were red.