### PR TITLE
fix(deps): resolve cargo audit vulnerabilities

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -8,15 +8,17 @@ ignore = [
     # Risk is low for our use case (internal database connections)
     "RUSTSEC-2023-0071",
 
-    # Denial of Service via Stack Exhaustion in `time`
-    # Fix requires time >=0.3.47, which requires rustc 1.88.0
-    # Project is pinned to 1.86.0 for Emscripten compatibility
-    "RUSTSEC-2026-0009",
-
     # tokio-tar PAX extended headers file smuggling
     # No fix available; comes from testcontainers (postgres-tests feature only)
     # Not exposed to untrusted input in our test infrastructure
     "RUSTSEC-2025-0111",
+
+    # quick-xml quadratic runtime / unbounded namespace allocation DoS
+    # Fix requires quick-xml >=0.41.0; pinned below that by s3-tokio 0.39.6
+    # (no newer release available). Only parses our own S3 API responses, not
+    # untrusted input.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 informational_warnings = ["unmaintained", "unsound"]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1827,11 +1827,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1841,11 +1839,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3564,14 +3564,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3693,6 +3694,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rav1e"


### PR DESCRIPTION
## Summary
- Bumps crossbeam-epoch and quinn-proto to patched versions (RUSTSEC-2026-0204, RUSTSEC-2026-0185)
- Adds a documented ignore for quick-xml's two DoS advisories (RUSTSEC-2026-0194/0195) -- no fix available yet since s3-tokio 0.39.6 pins it below 0.41, and it only parses our own S3 API responses
- Drops the stale `time`/rustc-1.86.0 ignore entry now that both have been bumped past the fixed versions

## Test plan
- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo nextest run --workspace` (282 passed)
- [x] `cargo audit` exits clean